### PR TITLE
use unzipper instead of unzip

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "commander": "^2.2.0",
     "path-extra": "^0.3.0",
     "tarball-extract": "0.0.6",
-    "unzip": "~0.1.11"
+    "unzipper": "^0.10.5"
   },
   "devDependencies": {
     "standard": "^10.0.2"

--- a/src/download.js
+++ b/src/download.js
@@ -2,7 +2,7 @@ var http = require('http')
 var os = require('os')
 var path = require('path-extra')
 var tarball = require('tarball-extract')
-var unzip = require('unzip')
+var unzip = require('unzipper')
 
 var env = require('./env')
 


### PR DESCRIPTION
using node-12.9.1 / npm 6.11.2 I get this warning on install: 

```
fusselwurm@wormfly3 ~/dev/misc/node-steamcmd (master) $ npm i
npm WARN deprecated natives@1.1.6: This module relies on Node.js's internals and will break at some point. Do not use it, and update to graceful-fs@4.x.
```

and subsequently, this error here:
```
fusselwurm@wormfly3 ~/dev/misc/node-steamcmd (master) $ ./bin/steamcmd 398830500
fs.js:27
const { Math, Object } = primordials;
                         ^

ReferenceError: primordials is not defined
    at fs.js:27:26
    at req_ (/home/fusselwurm/dev/misc/node-steamcmd/node_modules/natives/index.js:143:24)
    at Object.req [as require] (/home/fusselwurm/dev/misc/node-steamcmd/node_modules/natives/index.js:55:10)
    at Object.<anonymous> (/home/fusselwurm/dev/misc/node-steamcmd/node_modules/unzip/node_modules/graceful-fs/fs.js:1:37)
```

which can be fixed by using the `unzipper` package ([depending on graceful-fs 4.x](https://github.com/ZJONSSON/node-unzipper/blob/master/package.json#L32)) instead of the venerable `unzip`
